### PR TITLE
Update supported docker image OS

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -41,99 +41,99 @@ jobs:
         }      
       shell: powershell
 
-  build-linux:
+  build-ubuntu:
     needs: [get-version-number]
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3    
     
-    - name: Dockerhub Login
+    - name: DockerHub Login
       env:
         USERNAME: ${{ secrets.DOCKER_HUB_USER }}
         PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
       run: docker login --username $USERNAME --password "$PASSWORD"
     
-    - name: Build the Docker image 
-      env:
-        VERSION_NUMBER: ${{ needs.get-version-number.outputs.VERSION }}     
-      run: docker build ./ubuntu-1804 --tag octopuslabs/terraform-workertools:$VERSION_NUMBER-ubuntu.1804 --tag octopuslabs/terraform-workertools:latest-ubuntu.1804
-      if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }}
-      
-    - name: Push the version image
-      env:
-        VERSION_NUMBER: ${{ needs.get-version-number.outputs.VERSION }}     
-      run: docker push octopuslabs/terraform-workertools:$VERSION_NUMBER-ubuntu.1804
-      if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }}
-      
-    - name: Push the latest image
-      env:
-        VERSION_NUMBER: ${{ needs.get-version-number.outputs.VERSION }}     
-      run: docker push octopuslabs/terraform-workertools:latest-ubuntu.1804
-      if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }}
-
-    - name: Build the Docker image      
+    - name: Build the ubuntu.2004 Docker image 
       env:
         VERSION_NUMBER: ${{ needs.get-version-number.outputs.VERSION }}     
       run: docker build ./ubuntu-2004 --tag octopuslabs/terraform-workertools:$VERSION_NUMBER-ubuntu.2004 --tag octopuslabs/terraform-workertools:latest-ubuntu.2004
       if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }}
       
-    - name: Push the version image
+    - name: Push the ubuntu.2004 version image
       env:
         VERSION_NUMBER: ${{ needs.get-version-number.outputs.VERSION }}     
       run: docker push octopuslabs/terraform-workertools:$VERSION_NUMBER-ubuntu.2004
       if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }}
       
-    - name: Push the latest image
+    - name: Push the latest ubuntu.2004 image
       env:
         VERSION_NUMBER: ${{ needs.get-version-number.outputs.VERSION }}     
       run: docker push octopuslabs/terraform-workertools:latest-ubuntu.2004
       if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }}
+
+    - name: Build the ubuntu.2204 Docker image      
+      env:
+        VERSION_NUMBER: ${{ needs.get-version-number.outputs.VERSION }}     
+      run: docker build ./ubuntu-2204 --tag octopuslabs/terraform-workertools:$VERSION_NUMBER-ubuntu.2204 --tag octopuslabs/terraform-workertools:latest-ubuntu.2204
+      if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }}
       
-  build-windows-2019:
+    - name: Push the ubuntu.2204 version image
+      env:
+        VERSION_NUMBER: ${{ needs.get-version-number.outputs.VERSION }}     
+      run: docker push octopuslabs/terraform-workertools:$VERSION_NUMBER-ubuntu.2204
+      if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }}
+      
+    - name: Push the latest ubuntu.2204 image
+      env:
+        VERSION_NUMBER: ${{ needs.get-version-number.outputs.VERSION }}     
+      run: docker push octopuslabs/terraform-workertools:latest-ubuntu.2204
+      if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }}
+      
+  build-win-2019:
     needs: [get-version-number]
     runs-on: windows-2019
 
     steps:
     - uses: actions/checkout@v3
         
-    - name: Dockerhub Login
+    - name: DockerHub Login
       env:
         USERNAME: ${{ secrets.DOCKER_HUB_USER }}
         PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
       run: docker login --username ${env:USERNAME} --password "${env:PASSWORD}"
     
-    - name: Build the Docker image
+    - name: Build the win2019 Docker image
       env:
         VERSION_NUMBER: ${{ needs.get-version-number.outputs.VERSION }}     
       run: docker build ./windows-2019 --tag octopuslabs/terraform-workertools:${env:VERSION_NUMBER}-windows.2019 --tag octopuslabs/terraform-workertools:latest-windows.2019
       if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }}
       
-    - name: Push the version image
+    - name: Push the win2019 version image
       env:
         VERSION_NUMBER: ${{ needs.get-version-number.outputs.VERSION }}     
       run: docker push octopuslabs/terraform-workertools:${env:VERSION_NUMBER}-windows.2019
       if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }}
       
-    - name: Push the latest image
+    - name: Push the latest win2019 image
       env:
         VERSION_NUMBER: ${{ needs.get-version-number.outputs.VERSION }}     
       run: docker push octopuslabs/terraform-workertools:latest-windows.2019
       if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }}
   
   build-docker-manifest:
-    needs: [build-windows-2019, build-linux, get-version-number]
+    needs: [get-version-number, build-ubuntu, build-win-2019]
     runs-on: ubuntu-latest
     
     steps:
-    - name: Dockerhub Login
+    - name: DockerHub Login
       env:
         USERNAME: ${{ secrets.DOCKER_HUB_USER }}
         PASSWORD: ${{ secrets.DOCKER_HUB_PAT }}
       run: docker login --username $USERNAME --password "$PASSWORD"
       
     - name: Build Manifest
-      run: docker manifest create octopuslabs/terraform-workertools:latest octopuslabs/terraform-workertools:latest-windows.2019 octopuslabs/terraform-workertools:latest-ubuntu.1804
+      run: docker manifest create octopuslabs/terraform-workertools:latest octopuslabs/terraform-workertools:latest-windows.2019 octopuslabs/terraform-workertools:latest-ubuntu.2004
       if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }}
       
     - name: Push Manifest
@@ -143,7 +143,7 @@ jobs:
     - name: Build Version Manifest
       env:
         VERSION_NUMBER: ${{ needs.get-version-number.outputs.VERSION }}     
-      run: docker manifest create octopuslabs/terraform-workertools:$VERSION_NUMBER octopuslabs/terraform-workertools:$VERSION_NUMBER-windows.2019 octopuslabs/terraform-workertools:$VERSION_NUMBER-ubuntu.1804
+      run: docker manifest create octopuslabs/terraform-workertools:$VERSION_NUMBER octopuslabs/terraform-workertools:$VERSION_NUMBER-windows.2019 octopuslabs/terraform-workertools:$VERSION_NUMBER-ubuntu.2004
       if: ${{ needs.get-version-number.outputs.CONTINUE == 'Yes' }}
       
     - name: Push Version Manifest

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 This repository contains images that contain the tooling necessary to to use the execution container feature with Octopus Deploy when running commands against Terraform.
 
-- TerraForm
+- Terraform
 
-There are three images built in this repo:
+The following images are built in this repo:
 
-- Ubuntu 20.04
-- Ubuntu 18.04
-- Windows 2019
+- Ubuntu 22.04
+- Ubuntu 20.04 (tagged `latest` in [DockerHub](https://hub.docker.com/r/octopuslabs/terraform-workertools/tags?page=1&name=latest))
+- Windows 2019 (tagged `latest` in [DockerHub](https://hub.docker.com/r/octopuslabs/terraform-workertools/tags?page=1&name=latest))
 
-A new image will be built each time a new version of Teraform is created.  The version numbers will be based on the version of Terramform.
+A new image will be built each time a new version of Terraform is created.  The version numbers will be based on the version of Terraform.
 
-**This repository provided as is.  If there are any issues please do not contact support.**
+**Please consider this repository provided as is.  If there are any issues please do not contact support.**

--- a/ubuntu-1804/Dockerfile
+++ b/ubuntu-1804/Dockerfile
@@ -1,9 +1,0 @@
-FROM octopuslabs/workertools:latest-ubuntu.1804
-
-ARG DEBIAN_FRONTEND noninteractive
-
-# Get Terraform
-# https://computingforgeeks.com/how-to-install-terraform-on-ubuntu-centos-7/
-RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
-    apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" && \
-    apt-get update && apt-get install terraform -y

--- a/ubuntu-2204/Dockerfile
+++ b/ubuntu-2204/Dockerfile
@@ -1,4 +1,4 @@
-FROM octopuslabs/workertools:latest-ubuntu.2004
+FROM octopuslabs/workertools:latest-ubuntu.2204
 
 ARG DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Removes Ubuntu 18.04, adds Ubuntu 22.04, and makes 20.04 latest